### PR TITLE
Use application:ensure_all_started instead of starting thins manually.

### DIFF
--- a/src/heroku_erlang_example.erl
+++ b/src/heroku_erlang_example.erl
@@ -7,42 +7,23 @@
 -author('author <author@example.com>').
 -export([start/0, start_link/0, stop/0]).
 
-ensure_started(App) ->
-    case application:start(App) of
-        ok ->
-            ok;
-        {error, {already_started, App}} ->
-            ok
-    end.
-
 %% @spec start_link() -> {ok,Pid::pid()}
 %% @doc Starts the app for inclusion in a supervisor tree
 start_link() ->
-    ensure_started(inets),
-    ensure_started(crypto),
-    ensure_started(mochiweb),
     application:set_env(webmachine, webmachine_logger_module, 
                         webmachine_logger),
-    ensure_started(webmachine),
+    application:ensure_all_started(webmachine),
     heroku_erlang_example_sup:start_link().
 
 %% @spec start() -> ok
 %% @doc Start the heroku_erlang_example server.
 start() ->
-    ensure_started(inets),
-    ensure_started(crypto),
-    ensure_started(mochiweb),
     application:set_env(webmachine, webmachine_logger_module, 
                         webmachine_logger),
-    ensure_started(webmachine),
+    application:ensure_all_started(webmachine),
     application:start(heroku_erlang_example).
 
 %% @spec stop() -> ok
 %% @doc Stop the heroku_erlang_example server.
 stop() ->
-    Res = application:stop(heroku_erlang_example),
-    application:stop(webmachine),
-    application:stop(mochiweb),
-    application:stop(crypto),
-    application:stop(inets),
-    Res.
+    application:stop(heroku_erlang_example).


### PR DESCRIPTION
"foreman start" was failing because dependent apps weren't being started.  This uses application:ensure_all_started/1 to start everything including dependencies.  I'm not so sure about application:stop/1 since I don't really know OTP.
